### PR TITLE
Remove extraneous code from Dice.java

### DIFF
--- a/app/src/main/java/com/example/yarr/myfirstapp/Dice.java
+++ b/app/src/main/java/com/example/yarr/myfirstapp/Dice.java
@@ -13,27 +13,25 @@ public class Dice
     private int diceSides;
 
     public static final int DEFAULT_SIZE = 6;
+ 
+     // constructor
+    public Dice(int sides)
+    {
+        if (!setSides(sides))
+            sides = DEFAULT_SIZE;
+    }
 
     // actual dice roll math
     public static int diceRoll(int sidesDie)
     {
         Random rand = new Random();
-        int dieOne;
-        dieOne = rand.nextInt(sidesDie) + 1;
-        return dieOne;
+        return rand.nextInt(sidesDie) + 1;
     }
 
     // modifier math
     public static int addModify(int dieRoll, int modifier)
     {
         return dieRoll + modifier;
-    }
-
-    // constructor
-    public Dice(int sides)
-    {
-        if (!setSides(sides))
-            sides = DEFAULT_SIZE;
     }
 
     // getter


### PR DESCRIPTION
This removes extra code from `Dice::diceRoll`, also moves the constructor to the top of the class to adhere to common practice.